### PR TITLE
Add notebook-based test

### DIFF
--- a/tests/test_cal_mgs.py
+++ b/tests/test_cal_mgs.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import time
+import numpy as np
+import h5py
+
+# Ensure local package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from Mulguisin.mgs_class import mulguisin_type
+
+
+def run_notebook_example():
+    """Replicate the cal_mgs.ipynb workflow."""
+    data_path = os.path.join(os.path.dirname(__file__), "..", "test", "rand_gal_data_210218_sig10.hdf5")
+    with h5py.File(data_path, "r") as f:
+        x1 = np.array(f["x_rsd"])
+        y1 = np.array(f["y_rsd"])
+        z1 = np.array(f["z_rsd"])
+
+    mgs_cls = mulguisin_type("voronoi")
+    mgs = mgs_cls(10.0, x1, y1, z1)
+    t0 = time.time()
+    Nmgs, imgs, clg, clm, cng = mgs.get_mgs()
+    elapsed = time.time() - t0
+    return Nmgs, elapsed
+
+
+def test_notebook_dataset():
+    Nmgs, elapsed = run_notebook_example()
+    print(f"Notebook dataset -> groups: {Nmgs}, time: {elapsed:.6f}s")
+    assert Nmgs == 50
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import time
+import numpy as np
+
+# Ensure local package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from Mulguisin.mgs_class import mulguisin
+
+
+def run_2d_example(n=1000):
+    """Run a 2D clustering example with ``n`` points."""
+    rng = np.random.default_rng(0)
+    half = n // 2
+    cluster1 = rng.normal(0.0, 0.05, size=(half, 2))
+    cluster2 = rng.normal(1.0, 0.05, size=(n - half, 2))
+    data = np.vstack((cluster1, cluster2))
+    mgs = mulguisin(0.3, data[:, 0], data[:, 1], isort=np.arange(n))
+    t0 = time.time()
+    Nmgs, imgs, clg, clm, cng = mgs.get_mgs()
+    elapsed = time.time() - t0
+    return Nmgs, elapsed
+
+def run_3d_example(n=1000):
+    """Run a 3D clustering example with ``n`` points."""
+    rng = np.random.default_rng(1)
+    half = n // 2
+    cluster1 = rng.normal(0.0, 0.05, size=(half, 3))
+    cluster2 = rng.normal(1.0, 0.05, size=(n - half, 3))
+    data = np.vstack((cluster1, cluster2))
+    mgs = mulguisin(0.3, data[:, 0], data[:, 1], z1=data[:, 2], isort=np.arange(n))
+    t0 = time.time()
+    Nmgs, imgs, clg, clm, cng = mgs.get_mgs()
+    elapsed = time.time() - t0
+    return Nmgs, elapsed
+
+
+def test_mgs_2d():
+    Nmgs, elapsed = run_2d_example()
+    print(f"2D example -> groups: {Nmgs}, time: {elapsed:.6f}s")
+    assert Nmgs == 2
+
+
+def test_mgs_3d():
+    Nmgs, elapsed = run_3d_example()
+    print(f"3D example -> groups: {Nmgs}, time: {elapsed:.6f}s")
+    assert Nmgs == 2


### PR DESCRIPTION
## Summary
- replicate the `cal_mgs.ipynb` workflow in a new test
- check that running MGS on the provided galaxy dataset yields 50 groups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686229ec570c832c8d5479d04d4724a8