### PR TITLE
Add degree statistics helpers

### DIFF
--- a/Mulguisin/mgs_class.py
+++ b/Mulguisin/mgs_class.py
@@ -115,6 +115,28 @@ class mulguisin:
 			if self.clm[imgs][i] == self.clg[imgs][idgal]: degree+=1
 		if self.clg[imgs][idgal] != id_mom: degree += 1
 		return degree
+
+	def Get_Degrees(self, imgs=None):
+		"""Return degrees of all points in ``imgs`` cluster."""
+		return [self.Get_Degree(imgs, i) for i in range(self.cng[imgs])]
+
+	def Get_DegreeStats(self, imgs=None):
+		"""Return average and maximum degree of ``imgs`` cluster."""
+		deg = self.Get_Degrees(imgs)
+		if len(deg) == 0:
+			return 0.0, 0
+		arr = np.array(deg)
+		return float(arr.mean()), int(arr.max())
+
+	def Get_AllDegreeStats(self):
+		"""Return average and maximum degree for each cluster."""
+		avg = []
+		maxd = []
+		for i in range(self.Nmgs):
+			a, m = self.Get_DegreeStats(i)
+			avg.append(a)
+			maxd.append(m)
+		return avg, maxd
 	
 	def Get_Branch(self,imgs=None):
 		nbranch = 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -45,3 +45,16 @@ def test_mgs_3d():
     Nmgs, elapsed = run_3d_example()
     print(f"3D example -> groups: {Nmgs}, time: {elapsed:.6f}s")
     assert Nmgs == 2
+
+
+def test_degree_stats():
+    rng = np.random.default_rng(0)
+    half = 50
+    cluster1 = rng.normal(0.0, 0.05, size=(half, 2))
+    cluster2 = rng.normal(1.0, 0.05, size=(half, 2))
+    data = np.vstack((cluster1, cluster2))
+    mgs = mulguisin(0.3, data[:, 0], data[:, 1], isort=np.arange(2 * half))
+    mgs.get_mgs()
+    avg, mx = mgs.Get_AllDegreeStats()
+    assert np.allclose(avg, [1.96, 1.96])
+    assert mx == [5, 6]


### PR DESCRIPTION
## Summary
- expose helper methods for degree statistics on clusters
- test the new helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dcf050db8832c9ef156743ea3351d